### PR TITLE
Remove the need to update $ACT_PATH interactively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+SHELL=/usr/bin/env bash
+export ACT_PATH:=$(shell pwd)/src:$(ACT_PATH)
+
 all: runtest
 
 include $(ACT_HOME)/scripts/Makefile.std

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,7 @@ export ACT_PATH:=$(shell pwd)/src:$(ACT_PATH)
 
 all: runtest
 
+truth:
+	cd test && ./testgen.sh
+
 include $(ACT_HOME)/scripts/Makefile.std

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # act-starter
  Skeleton repository for ACT projects. 
 
-Setup: 
-- Export ACT_PATH to point to the src folder.
-- `export ACT_PATH=$(pwd)/src:$ACT_PATH` if you're in the folder where this README is located.
-
 Generating Tests:
 - See `test` for folder structure. 
 - Each folder in `test` contains one test case. 


### PR DESCRIPTION
If we set it in the makefile, we don't modify the current environment. This may avoid some statefulness problems ;)