### PR TITLE
~Make sure `stderr` is empty and~ allow verbose output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL=/usr/bin/env bash
 export ACT_PATH:=$(shell pwd)/src:$(ACT_PATH)
+export ACT_TEST_VERBOSE=0
 
 all: runtest
 

--- a/test/run_actsim_tests.sh
+++ b/test/run_actsim_tests.sh
@@ -6,6 +6,11 @@ echo "*                 Testing with actsim                     *"
 echo "***********************************************************"
 echo
 
+txtgreen='\e[32m'
+txtred="\e[31m"
+txtbold="\e[1m"
+txtreset="\e[0m"
+
 check_echo=0
 myecho()
 {
@@ -62,8 +67,16 @@ do
 		ok=1
 		if ! cmp $process_name.processed $process_name.truth >/dev/null 2>/dev/null
 		then
-			echo 
-			myecho "** FAILED TEST $subdir$fn_actfile: stdout mismatch"
+			myecho "** ${txtred}FAILED TEST${txtreset} $subdir$fn_actfile: stdout mismatch"
+			echo
+			if [ ${ACT_TEST_VERBOSE} -eq 1 ]; then
+				echo "${txtbold}stdout:${txtreset}"
+				cat $process_name.processed
+				echo "${txtbold}truth:${txtreset}"
+				cat $process_name.truth
+				echo "${txtbold}stderr:${txtreset}"
+				cat $process_name.stderr
+			fi
 			fail=`expr $fail + 1`
 			ok=0
 		fi
@@ -93,13 +106,13 @@ if [ $fail -ne 0 ]
 then
 	if [ $fail -eq 1 ]
 	then
-		echo "--- Summary: 1 test failed ---"
+		echo "--- ${txtred}1 test failed.${txtreset} ---"
 	else
-		echo "--- Summary: $fail tests failed ---"
+		echo "--- ${txtred}$fail tests failed.${txtreset} ---"
 	fi
 	exit 1
 else
 	echo
-	echo "SUCCESS! All tests passed."
+	echo "--- ${txtgreen}All tests passed.${txtreset} ---"
 fi
 echo


### PR DESCRIPTION
- ~~previously stderr could be nonempty (e.g., error from importing a nonexistent module), but the tests would still be marked as "pass" as long as the stdout matches expectations. i think this is surprising behaviour and should be avoided~~
- i find it useful to directly see what caused a test to fail, hence one can now run the tests with an additional argument to the makefile to get more informative output on fail: `make ACT_TEST_VERBOSE=1`