### PR TITLE
Support filtering of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL=/usr/bin/env bash
 export ACT_PATH:=$(shell pwd)/src:$(ACT_PATH)
 export ACT_TEST_VERBOSE=0
+export ACT_TEST_FILTER_REGEX=
 
 all: test
 

--- a/test/run_actsim_tests.sh
+++ b/test/run_actsim_tests.sh
@@ -46,7 +46,7 @@ fn_actsim_script="test.actsim"
 
 for subdir in ./*/
 do
-	if [ -d $subdir ]; then
+	if [ -d $subdir ] && ([ -z "$ACT_TEST_FILTER_REGEX" ] || ([ -n "$ACT_TEST_FILTER_REGEX" ] && [[ $subdir =~ $ACT_TEST_FILTER_REGEX ]])); then
 		cd "$subdir"
 
 		if [ $num -lt 10 ]

--- a/test/run_actsim_tests.sh
+++ b/test/run_actsim_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 stderr_check=$1
 
@@ -27,9 +27,9 @@ myecho()
   fi
   if [ $check_echo -eq 1 ]
   then
-	echo -n "$@"
+	echo -e -n "$@"
   else
-	echo "$@\c"
+	echo -e "$@\c"
   fi
 }
 
@@ -72,11 +72,11 @@ do
 			myecho "** ${txtred}FAILED TEST${txtreset} $subdir$fn_actfile: stdout mismatch"
 			echo
 			if [ ${ACT_TEST_VERBOSE} -eq 1 ]; then
-				echo "${txtbold}stdout:${txtreset}"
+				echo -e "${txtbold}stdout:${txtreset}"
 				cat $process_name.processed
-				echo "${txtbold}truth:${txtreset}"
+				echo -e "${txtbold}truth:${txtreset}"
 				cat $process_name.truth
-				echo "${txtbold}stderr:${txtreset}"
+				echo -e "${txtbold}stderr:${txtreset}"
 				cat $process_name.stderr
 			fi
 			fail=`expr $fail + 1`
@@ -120,13 +120,13 @@ if [ $fail -ne 0 ]
 then
 	if [ $fail -eq 1 ]
 	then
-		echo "--- ${txtred}1 test failed.${txtreset} ---"
+		echo -e "--- ${txtred}1 test failed.${txtreset} ---"
 	else
-		echo "--- ${txtred}$fail tests failed.${txtreset} ---"
+		echo -e "--- ${txtred}$fail tests failed.${txtreset} ---"
 	fi
 	exit 1
 else
 	echo
-	echo "--- ${txtgreen}All tests passed.${txtreset} ---"
+	echo -e "--- ${txtgreen}All tests passed.${txtreset} ---"
 fi
 echo


### PR DESCRIPTION
- one can now provide a regex (yeah, yeah, i know ;) ) to filter which subdirectories are included in the tests. i find this very helpful when working on one specific test
- unfortunately `sh` does not support regex pattern matching, hence i needed to switch to `bash`

branches of from #5, so should be merged after